### PR TITLE
Add Boot sequence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,6 +2051,7 @@ dependencies = [
  "bevy_kira_audio",
  "bevy_webgl2",
  "console_error_panic_hook",
+ "parking_lot",
  "serde",
  "serde_json",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ bevy-inspector-egui = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.4"
+parking_lot = "0.11"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bevy_webgl2 = { version="0.5", optional=true }

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -1,0 +1,76 @@
+use crate::{loader::Loader, AppState};
+use bevy::prelude::*;
+
+pub struct UiResources {
+    title_font: Handle<Font>,
+    text_font: Handle<Font>,
+}
+
+impl UiResources {
+    pub fn new() -> Self {
+        UiResources {
+            title_font: Default::default(),
+            text_font: Default::default(),
+        }
+    }
+
+    pub fn title_font(&self) -> Handle<Font> {
+        self.title_font.clone()
+    }
+
+    pub fn text_font(&self) -> Handle<Font> {
+        self.text_font.clone()
+    }
+}
+
+/// Marker component for the boot sequence entity holding the [`Loader`] which
+/// handles the critical boot assets.
+struct Boot;
+
+fn boot_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let mut loader = Loader::new();
+    loader.enqueue("fonts/pacifico/Pacifico-Regular.ttf");
+    loader.enqueue("fonts/mochiy_pop_one/MochiyPopOne-Regular.ttf");
+    commands.spawn().insert(Boot).insert(loader);
+}
+
+fn boot(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut query: Query<(Entity, &mut Loader, With<Boot>)>,
+    mut ui_resouces: ResMut<UiResources>,
+    mut state: ResMut<State<AppState>>,
+) {
+    if let Ok((id, loader, _)) = query.single_mut() {
+        if loader.is_done() {
+            // Destroy the Boot entity
+            commands.entity(id).despawn();
+
+            // Populate the UI resources
+            let title_font: Handle<Font> = asset_server.load("fonts/pacifico/Pacifico-Regular.ttf");
+            assert!(asset_server.get_load_state(&title_font) == bevy::asset::LoadState::Loaded);
+            let text_font: Handle<Font> =
+                asset_server.load("fonts/mochiy_pop_one/MochiyPopOne-Regular.ttf");
+            assert!(asset_server.get_load_state(&text_font) == bevy::asset::LoadState::Loaded);
+            *ui_resouces = UiResources {
+                title_font,
+                text_font,
+            };
+
+            // Change app state to load the main menu
+            assert!(*state.current() == AppState::Boot);
+            state.set(AppState::MainMenu).unwrap();
+        }
+    }
+}
+
+/// Plugin to load the critical assets before the any loading screen can be displayed.
+pub struct BootPlugin;
+
+impl Plugin for BootPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.insert_resource(UiResources::new())
+            .add_system_set(SystemSet::on_enter(AppState::Boot).with_system(boot_setup.system()))
+            .add_system_set(SystemSet::on_update(AppState::Boot).with_system(boot.system()));
+    }
+}

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,133 @@
+use bevy::prelude::*;
+use parking_lot::Mutex;
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+pub struct Loader {
+    count: AtomicUsize,
+    request_queue: Mutex<Vec<String>>,
+    work_queue: Mutex<Vec<HandleUntyped>>,
+}
+
+impl Loader {
+    pub fn new() -> Self {
+        Loader {
+            count: AtomicUsize::new(0),
+            request_queue: Mutex::new(vec![]),
+            work_queue: Mutex::new(vec![]),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pending_count() == 0
+    }
+
+    pub fn pending_count(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    pub fn is_done(&self) -> bool {
+        // Keep request queue locked while reading count to avoid race condition
+        self.is_empty()
+    }
+
+    pub fn enqueue(&mut self, path: &str) {
+        self.request_queue.lock().push(path.to_owned());
+        self.count.fetch_add(1, Ordering::Release);
+        trace!("Enqueued request: {} ({}/{})", path, self.request_queue.lock().len(), self.count.load(Ordering::Relaxed));
+    }
+
+    pub fn tick(&mut self, asset_server: &AssetServer) {
+        // Check pending asset loading requests and remove completed ones
+        {
+            let mut work_queue = self.work_queue.lock();
+            // TODO - Vec::drain_filter()
+            let mut i = 0;
+            while i < work_queue.len() {
+                let handle = &work_queue[i];
+                let state = asset_server.get_load_state(handle);
+                if state == bevy::asset::LoadState::Loaded
+                    || state == bevy::asset::LoadState::Failed
+                {
+                    trace!("Asset finished loading: {:?}", handle);
+                    work_queue.remove(i);
+                    if self.count.fetch_sub(1, Ordering::Acquire) == 1 {
+                        // Finished last loading
+                    }
+                } else {
+                    i += 1;
+                }
+            }
+        }
+
+        // Swap request queue atomically
+        let mut request_queue: Vec<String> = {
+            let mut request_queue = self.request_queue.lock();
+            std::mem::replace(&mut request_queue, vec![])
+        };
+        
+        // Drain request queue and enqueue new asset loading requests
+        for path in request_queue.drain(..) {
+            let handle = asset_server.load_untyped(&path[..]);
+            // Only enqueue if not loaded; otherwise either the resource is already loading
+            // (need to wait), is loaded (nothing to do), or failed (no point retrying).
+            match asset_server.get_load_state(&handle) {
+                bevy::asset::LoadState::NotLoaded | bevy::asset::LoadState::Loading => {
+                    trace!("Start loading asset: {} -> {:?}", path, &handle);
+                    self.work_queue.lock().push(handle);
+                },
+                bevy::asset::LoadState::Loaded | bevy::asset::LoadState::Failed => {
+                    trace!("Asset: {} -> {:?}", path, &handle);
+                    self.count.fetch_sub(1, Ordering::Release);
+                },
+            }
+        }
+    }
+}
+
+fn tick_loaders(asset_server: Res<AssetServer>, mut query: Query<(&mut Loader,)>) {
+    let asset_server: &AssetServer = &*asset_server;
+    for (mut loader,) in query.iter_mut() {
+        loader.tick(asset_server);
+    }
+}
+
+pub struct LoaderPlugin;
+
+static LOADER_STAGE: &str = "loader";
+
+impl Plugin for LoaderPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        // Add Level resource and event
+        app.add_stage_before(
+            CoreStage::First,
+            LOADER_STAGE,
+            SystemStage::single_threaded(),
+        )
+        .add_system_to_stage(LOADER_STAGE, tick_loaders.system());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let loader = Loader::new();
+        assert!(loader.is_empty());
+        assert_eq!(loader.pending_count(), 0);
+    }
+
+    #[test]
+    fn enqueue() {
+        let mut loader = Loader::new();
+        loader.enqueue("dummy");
+        assert!(!loader.is_empty());
+        assert_eq!(loader.pending_count(), 1);
+        //let asset_server = AssetServer::new(asset_io, task_queue);
+        //loader.work(&asset_server);
+    }
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -2,7 +2,7 @@ use bevy::{app::AppExit, prelude::*};
 use serde::Deserialize;
 use std::{collections::HashMap, fs::File, io::Read};
 
-use crate::{inventory::Buildable, text_asset::TextAsset, Error};
+use crate::{inventory::Buildable, text_asset::TextAsset, AppState, Error};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BuildableRef(pub String);
@@ -208,6 +208,7 @@ fn load_config(
                 let color_unselected = Color::rgba(1.0, 1.0, 1.0, 0.5);
                 let color_selected = Color::rgba(1.0, 1.0, 1.0, 1.0);
                 let color_empty = Color::rgba(1.0, 0.8, 0.8, 0.5);
+
                 // Load referenced assets
                 let mut buildables = HashMap::new();
                 for (item_name, rules) in game_data_archive.inventory.iter() {
@@ -250,6 +251,7 @@ fn load_config(
                     );
                 }
                 *buildables_res = Buildables { buildables };
+
                 // Convert levels
                 let levels: Vec<_> = game_data_archive
                     .levels
@@ -287,6 +289,8 @@ impl Plugin for SerializePlugin {
             .insert_resource(ConfigLoadState::Unloaded)
             .insert_resource(Buildables::new())
             .add_event::<ConfigLoadedEvent>()
-            .add_system(load_config.system());
+            .add_system_set(
+                SystemSet::on_update(AppState::MainMenu).with_system(load_config.system()),
+            );
     }
 }


### PR DESCRIPTION
Add an `AppState::Boot` state before the main menu, which loads the
critical assets (mainly, fonts) required to display a loading screen,
and without which the game cannot start. The sequence should be kept
minimal as no user interaction can be provided during this time. Most
loading should occur during the `AppState::MainMenu` state that follows,
where some progress and feedback can be displayed.